### PR TITLE
Add Google tracking code

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -116,6 +116,11 @@ const config: Config = {
       disableSwitch: false,
       respectPrefersColorScheme: true,
     },
+    // Google Analytics configuration
+    gtag: {
+      trackingID: 'G-YJD1R6PLTV',
+      anonymizeIP: true,
+    },
     navbar: {
       title: 'Ψ',
       items: [


### PR DESCRIPTION
Google Analytics tracking was integrated by modifying `docusaurus.config.ts`.

*   The `gtag` configuration object was added to `docusaurus.config.ts`.
*   The `trackingID` was set to `'G-YJD1R6PLTV'`.
*   `anonymizeIP` was set to `true` for enhanced privacy compliance.

This method aligns with Docusaurus's recommended approach for Google Analytics integration, which automatically injects the necessary tracking scripts without requiring manual script tag insertion. The configuration ensures consistent tracking across all pages and locales.